### PR TITLE
Fix MDN Docs resource URL

### DIFF
--- a/features-json/nav-timing.json
+++ b/features-json/nav-timing.json
@@ -5,7 +5,7 @@
   "status":"rec",
   "links":[
     {
-      "url":"https://developer.mozilla.org/en/API/navigationTiming",
+      "url":"https://developer.mozilla.org/en-US/docs/Web/API/Navigation_timing_API",
       "title":"MDN Web Docs - Navigation Timing"
     },
     {


### PR DESCRIPTION
MDN Docs resource moved to https://developer.mozilla.org/en-US/docs/Web/API/Navigation_timing_API